### PR TITLE
[Feat] #28 - 둘러보기 뷰 카테고리 UI 구현

### DIFF
--- a/Myhouse/Global/Literals/StringLiterals.swift
+++ b/Myhouse/Global/Literals/StringLiterals.swift
@@ -35,6 +35,7 @@ struct I18N {
     }
     
     struct Look {
+        static let tabBarTitleList = ["팔로잉", "사진", "집들이", "노하우", "전문가 집들이"]
         static let tagData = ["모던한", "화려한", "레트로감성", "우드", "화이트톤", "심플한"]
     }
 }

--- a/Myhouse/Myhouse.xcodeproj/project.pbxproj
+++ b/Myhouse/Myhouse.xcodeproj/project.pbxproj
@@ -50,6 +50,11 @@
 		694D30362A115D3500D84149 /* ScarpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694D30352A115D3500D84149 /* ScarpViewController.swift */; };
 		694D30382A115D5D00D84149 /* ScrapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694D30372A115D5D00D84149 /* ScrapView.swift */; };
 		69871FE62A18D28D00261CBC /* ScrapPopUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69871FE52A18D28D00261CBC /* ScrapPopUpView.swift */; };
+		69871FEA2A1B051D00261CBC /* LookPagingTabBarCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69871FE92A1B051D00261CBC /* LookPagingTabBarCollectionViewCell.swift */; };
+		69871FEC2A1B0B7D00261CBC /* LookPagingTabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69871FEB2A1B0B7D00261CBC /* LookPagingTabBarView.swift */; };
+		69871FEE2A1B0FCB00261CBC /* LookPagingCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69871FED2A1B0FCB00261CBC /* LookPagingCollectionViewCell.swift */; };
+		69871FF02A1B115200261CBC /* LookingPagingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69871FEF2A1B115200261CBC /* LookingPagingView.swift */; };
+		69871FF22A1B139D00261CBC /* LookView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69871FF12A1B139D00261CBC /* LookView.swift */; };
 		698A502E2A18A200006A7903 /* CategoryDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698A502D2A18A200006A7903 /* CategoryDataModel.swift */; };
 		698A50302A18A22B006A7903 /* ColorLightDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698A502F2A18A22B006A7903 /* ColorLightDataModel.swift */; };
 		698A50322A18A250006A7903 /* IdeaDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698A50312A18A250006A7903 /* IdeaDataModel.swift */; };
@@ -124,6 +129,11 @@
 		694D30352A115D3500D84149 /* ScarpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScarpViewController.swift; sourceTree = "<group>"; };
 		694D30372A115D5D00D84149 /* ScrapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapView.swift; sourceTree = "<group>"; };
 		69871FE52A18D28D00261CBC /* ScrapPopUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapPopUpView.swift; sourceTree = "<group>"; };
+		69871FE92A1B051D00261CBC /* LookPagingTabBarCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LookPagingTabBarCollectionViewCell.swift; sourceTree = "<group>"; };
+		69871FEB2A1B0B7D00261CBC /* LookPagingTabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LookPagingTabBarView.swift; sourceTree = "<group>"; };
+		69871FED2A1B0FCB00261CBC /* LookPagingCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LookPagingCollectionViewCell.swift; sourceTree = "<group>"; };
+		69871FEF2A1B115200261CBC /* LookingPagingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LookingPagingView.swift; sourceTree = "<group>"; };
+		69871FF12A1B139D00261CBC /* LookView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LookView.swift; sourceTree = "<group>"; };
 		698A502D2A18A200006A7903 /* CategoryDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryDataModel.swift; sourceTree = "<group>"; };
 		698A502F2A18A22B006A7903 /* ColorLightDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorLightDataModel.swift; sourceTree = "<group>"; };
 		698A50312A18A250006A7903 /* IdeaDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdeaDataModel.swift; sourceTree = "<group>"; };
@@ -450,6 +460,9 @@
 			isa = PBXGroup;
 			children = (
 				69956BDB2A179A3D0044F489 /* LookCollectionView.swift */,
+				69871FEB2A1B0B7D00261CBC /* LookPagingTabBarView.swift */,
+				69871FEF2A1B115200261CBC /* LookingPagingView.swift */,
+				69871FF12A1B139D00261CBC /* LookView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -459,6 +472,8 @@
 			children = (
 				69956BDD2A179A660044F489 /* FeedCollectionViewCell.swift */,
 				69956BDF2A179A9D0044F489 /* TagCollectionViewCell.swift */,
+				69871FE92A1B051D00261CBC /* LookPagingTabBarCollectionViewCell.swift */,
+				69871FED2A1B0FCB00261CBC /* LookPagingCollectionViewCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -617,9 +632,12 @@
 				9BF93D7A2A12451500FE3B5B /* DivisionFooterView.swift in Sources */,
 				9BF93D8C2A12AF0600FE3B5B /* TodaysDataModel.swift in Sources */,
 				69A199732A154BB500D4574B /* FolderBottomSheetViewController.swift in Sources */,
+				69871FEA2A1B051D00261CBC /* LookPagingTabBarCollectionViewCell.swift in Sources */,
 				694D2FFC2A10B81B00D84149 /* UIVIew+.swift in Sources */,
 				094373FC2A14B0AA003C8AFD /* TodaysIdeasCollectionVIewCell.swift in Sources */,
+				69871FEC2A1B0B7D00261CBC /* LookPagingTabBarView.swift in Sources */,
 				694D30262A113ECA00D84149 /* BaseView.swift in Sources */,
+				69871FF02A1B115200261CBC /* LookingPagingView.swift in Sources */,
 				0933C3F52A0F790100A4F163 /* DummyClass.swift in Sources */,
 				9B2A301E2A13CC8D0036ECB8 /* ModernDataModel.swift in Sources */,
 				694D30202A113A5200D84149 /* MyPageViewController.swift in Sources */,
@@ -650,6 +668,7 @@
 				69956BB62A155E110044F489 /* ScrapDataModel.swift in Sources */,
 				694D30002A10B89300D84149 /* UIButton+.swift in Sources */,
 				0951B69D2A135E6D00134B6A /* ColorLightCollectionViewCell.swift in Sources */,
+				69871FF22A1B139D00261CBC /* LookView.swift in Sources */,
 				694D300B2A10BA9C00D84149 /* UICollectionViewRegisterable.swift in Sources */,
 				698A502E2A18A200006A7903 /* CategoryDataModel.swift in Sources */,
 				694D2FFE2A10B85700D84149 /* UITextField+.swift in Sources */,
@@ -671,6 +690,7 @@
 				0951B69B2A13376A00134B6A /* CategoryCollectionViewCell.swift in Sources */,
 				69A199712A153DFD00D4574B /* FolderBottomSheetView.swift in Sources */,
 				699786052A101236005BC69E /* FontLiterals.swift in Sources */,
+				69871FEE2A1B0FCB00261CBC /* LookPagingCollectionViewCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Myhouse/Presentation/Common/Scrap/ScrapButton.swift
+++ b/Myhouse/Presentation/Common/Scrap/ScrapButton.swift
@@ -9,16 +9,11 @@ import UIKit
 
 // MARK: - Protocols
 
-protocol ScrapCVCDelegate: AnyObject {
-    func scrapCVCButtonTapped()
-}
-
 final class ScrapButton: UIButton {
     
     // MARK: - Properties
     
     var handler: (() -> Void)?
-    weak var delegate: ScrapCVCDelegate?
     
     var isTapped: Bool = false {
         didSet {
@@ -55,7 +50,7 @@ extension ScrapButton {
     
     @objc func scrapButtonTapped() {
         if !(isTapped) {
-            delegate?.scrapCVCButtonTapped()
+            NotificationCenter.default.post(name: Notification.Name("ScrapButtonTappedNotification"), object: nil)
         }
         handler?()
     }

--- a/Myhouse/Presentation/Common/TabBarViewController.swift
+++ b/Myhouse/Presentation/Common/TabBarViewController.swift
@@ -28,6 +28,7 @@ final class TabBarController: UITabBarController {
         super.viewDidLoad()
         
         setTabBar()
+        setNotificationCenter()
         setDelegate()
         setLayout()
     }
@@ -36,6 +37,10 @@ final class TabBarController: UITabBarController {
         super.viewWillAppear(animated)
         
         self.navigationController?.isNavigationBarHidden = true
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 }
 
@@ -67,9 +72,11 @@ private extension TabBarController {
         return tab
     }
     
+    func setNotificationCenter() {
+        NotificationCenter.default.addObserver(self, selector: #selector(scrapButtonTapped), name: Notification.Name("ScrapButtonTappedNotification"), object: nil)
+    }
+    
     func setDelegate() {
-        guard let lookViewController = self.lookViewController as? LookViewController else { return }
-        lookViewController.scrapButtonTapped = { self.scrapCVCButtonTapped() }
         scrapPopUpView.delegate = self
     }
     
@@ -110,10 +117,8 @@ private extension TabBarController {
         tabBar.backgroundColor = .white
         tabBar.isTranslucent = false
     }
-}
-
-extension TabBarController: ScrapCVCDelegate {
-    func scrapCVCButtonTapped() {
+    
+    @objc func scrapButtonTapped() {
         self.scrapPopUpView.snp.updateConstraints { $0.bottom.equalToSuperview() }
         UIView.animate(withDuration: 0.3) {
             self.view.layoutIfNeeded()

--- a/Myhouse/Presentation/Common/TabBarViewController.swift
+++ b/Myhouse/Presentation/Common/TabBarViewController.swift
@@ -131,6 +131,7 @@ extension TabBarController: ScrapCVCDelegate {
 extension TabBarController: ScrapPopUpDelegate {
     func scrapBookButtonTapped() {
         let scrapViewController = ScarpViewController()
+        self.navigationController?.isNavigationBarHidden = false
         self.navigationController?.pushViewController(scrapViewController, animated: false)
     }
     

--- a/Myhouse/Presentation/LookScene/LookView/Cell/LookPagingCollectionViewCell.swift
+++ b/Myhouse/Presentation/LookScene/LookView/Cell/LookPagingCollectionViewCell.swift
@@ -1,0 +1,46 @@
+//
+//  LookPagingCollectionViewCell.swift
+//  Myhouse
+//
+//  Created by 최영린 on 2023/05/22.
+//
+
+import UIKit
+
+import SnapKit
+
+final class LookPagingCollectionViewCell: UICollectionViewCell, UICollectionViewRegisterable {
+    
+    // MARK: - Properties
+    
+    static var isFromNib: Bool = false
+    
+    // MARK: - UI Components
+    
+    lazy var lookCollectionView = LookCollectionView()
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Extensions
+
+extension LookPagingCollectionViewCell {
+    
+    private func setLayout() {
+        contentView.addSubviews(lookCollectionView)
+
+        lookCollectionView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}

--- a/Myhouse/Presentation/LookScene/LookView/Cell/LookPagingTabBarCollectionViewCell.swift
+++ b/Myhouse/Presentation/LookScene/LookView/Cell/LookPagingTabBarCollectionViewCell.swift
@@ -1,0 +1,78 @@
+//
+//  LookPagingTabCollectionViewCell.swift
+//  Myhouse
+//
+//  Created by 최영린 on 2023/05/22.
+//
+
+import UIKit
+
+import SnapKit
+
+final class LookPagingTabBarCollectionViewCell: UICollectionViewCell, UICollectionViewRegisterable {
+    
+    // MARK: - Properties
+    
+    static var isFromNib: Bool = false
+    
+    // MARK: - UI Components
+    
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .NotoBold(size: 14)
+        label.textAlignment = .center
+        label.textColor = .black
+        return label
+    }()
+    
+    private lazy var underline: UIView = {
+        let view = UIView()
+        view.backgroundColor = .main
+        view.alpha = 0.0
+        return view
+    }()
+    
+    override var isSelected: Bool {
+        didSet {
+            titleLabel.textColor = isSelected ? .main : .black
+            underline.alpha = isSelected ? 1.0 : 0.0
+        }
+    }
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Extensions
+
+extension LookPagingTabBarCollectionViewCell {
+    
+    private func setLayout() {
+        contentView.addSubviews(titleLabel, underline)
+        
+        titleLabel.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(10)
+            $0.centerY.equalToSuperview()
+        }
+        
+        underline.snp.makeConstraints {
+            $0.height.equalTo(3)
+            $0.leading.equalTo(titleLabel.snp.leading)
+            $0.trailing.equalTo(titleLabel.snp.trailing)
+            $0.bottom.equalToSuperview()
+        }
+    }
+    
+    func setTitle(text: String?) {
+        self.titleLabel.text = text
+    }
+}

--- a/Myhouse/Presentation/LookScene/LookView/View/LookCollectionView.swift
+++ b/Myhouse/Presentation/LookScene/LookView/View/LookCollectionView.swift
@@ -11,8 +11,6 @@ final class LookCollectionView: BaseView {
     
     // MARK: - Properties
     
-    var scrapButtonTapped: (() -> Void)?
-    
     private var lookData = LookDataModel.dummy() {
         didSet {
             self.lookCollectionView.reloadData()
@@ -154,18 +152,11 @@ extension LookCollectionView: UICollectionViewDataSource {
         case .feed:
             let cell = FeedCollectionViewCell.dequeueReusableCell(collectionView: collectionView, indexPath: indexPath)
             cell.configureCell(lookData[indexPath.item])
-            cell.scrapButton.delegate = self
             cell.scrapButton.handler = { [weak self] in
                 guard let self else { return }
                 self.lookData[indexPath.item].isScrap.toggle()
             }
             return cell
         }
-    }
-}
-
-extension LookCollectionView: ScrapCVCDelegate {
-    func scrapCVCButtonTapped() {
-        scrapButtonTapped?()
     }
 }

--- a/Myhouse/Presentation/LookScene/LookView/View/LookPagingTabBarView.swift
+++ b/Myhouse/Presentation/LookScene/LookView/View/LookPagingTabBarView.swift
@@ -29,7 +29,7 @@ final class LookPagingTabBarView: BaseView {
         
         layout.estimatedItemSize = CGSize(width: 100, height: 44)
         layout.sectionInset = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
-        layout.minimumInteritemSpacing = 8
+        layout.minimumLineSpacing = 10
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.backgroundColor = .white
         collectionView.showsHorizontalScrollIndicator = false
@@ -44,6 +44,7 @@ final class LookPagingTabBarView: BaseView {
         
         registerCell()
         setDelegate()
+        setSelectedCell()
     }
     
     @available(*, unavailable)
@@ -51,16 +52,11 @@ final class LookPagingTabBarView: BaseView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func setUI() {
-        let indexPath = IndexPath(item: 0, section: 0)
-        delegate?.didTapPagingTabBarCell(scrollTo: indexPath) // 이동 이벤트를 처리하기 위해 delegate 호출
-    }
-    
     override func setLayout() {
         self.addSubviews(tabBarcollectionView)
         
-        tabBarcollectionView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
+        tabBarcollectionView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
     }
 }
@@ -70,15 +66,15 @@ final class LookPagingTabBarView: BaseView {
 extension LookPagingTabBarView {
     func registerCell() {
         LookPagingTabBarCollectionViewCell.register(target: tabBarcollectionView)
-        DispatchQueue.main.async {
-            let indexPath = IndexPath(item: 0, section: 0)
-            self.tabBarcollectionView.selectItem(at: indexPath, animated: false, scrollPosition: .centeredHorizontally)
-        }
     }
     
     func setDelegate() {
         tabBarcollectionView.delegate = self
         tabBarcollectionView.dataSource = self
+    }
+    
+    func setSelectedCell() {
+        tabBarcollectionView.selectItem(at: IndexPath(row: 0, section: 0), animated: true, scrollPosition: [])
     }
 }
 

--- a/Myhouse/Presentation/LookScene/LookView/View/LookPagingTabBarView.swift
+++ b/Myhouse/Presentation/LookScene/LookView/View/LookPagingTabBarView.swift
@@ -1,0 +1,102 @@
+//
+//  LookPagingTabBarView.swift
+//  Myhouse
+//
+//  Created by 최영린 on 2023/05/22.
+//
+
+import UIKit
+
+import SnapKit
+
+// MARK: - Protocols
+
+protocol PagingDelegate: AnyObject {
+    func didTapPagingTabBarCell(scrollTo indexPath: IndexPath)
+}
+
+final class LookPagingTabBarView: BaseView {
+    
+    // MARK: - Properties
+    
+    weak var delegate: PagingDelegate?
+    
+    // MARK: - UI Components
+    
+    lazy var tabBarcollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        
+        layout.estimatedItemSize = CGSize(width: 100, height: 44)
+        layout.sectionInset = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
+        layout.minimumInteritemSpacing = 8
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.backgroundColor = .white
+        collectionView.showsHorizontalScrollIndicator = false
+        collectionView.isScrollEnabled = false
+        return collectionView
+    }()
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        registerCell()
+        setDelegate()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func setUI() {
+        let indexPath = IndexPath(item: 0, section: 0)
+        delegate?.didTapPagingTabBarCell(scrollTo: indexPath) // 이동 이벤트를 처리하기 위해 delegate 호출
+    }
+    
+    override func setLayout() {
+        self.addSubviews(tabBarcollectionView)
+        
+        tabBarcollectionView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+}
+
+// MARK: - Extensions
+
+extension LookPagingTabBarView {
+    func registerCell() {
+        LookPagingTabBarCollectionViewCell.register(target: tabBarcollectionView)
+        DispatchQueue.main.async {
+            let indexPath = IndexPath(item: 0, section: 0)
+            self.tabBarcollectionView.selectItem(at: indexPath, animated: false, scrollPosition: .centeredHorizontally)
+        }
+    }
+    
+    func setDelegate() {
+        tabBarcollectionView.delegate = self
+        tabBarcollectionView.dataSource = self
+    }
+}
+
+extension LookPagingTabBarView: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        delegate?.didTapPagingTabBarCell(scrollTo: indexPath)
+        collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
+    }
+}
+
+extension LookPagingTabBarView: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return I18N.Look.tabBarTitleList.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = LookPagingTabBarCollectionViewCell.dequeueReusableCell(collectionView: collectionView, indexPath: indexPath)
+        cell.setTitle(text: I18N.Look.tabBarTitleList[indexPath.item])
+        return cell
+    }
+}

--- a/Myhouse/Presentation/LookScene/LookView/View/LookView.swift
+++ b/Myhouse/Presentation/LookScene/LookView/View/LookView.swift
@@ -1,0 +1,68 @@
+//
+//  LookView.swift
+//  Myhouse
+//
+//  Created by 최영린 on 2023/05/22.
+//
+
+import UIKit
+
+final class LookView: BaseView {
+    
+    // MARK: - UI Components
+    
+    private lazy var lookPagingTabBarView = LookPagingTabBarView()
+    private lazy var lookPagingView = LookingPagingView()
+    private let lineView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .lightGray
+        return view
+    }()
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setDelegate()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func setLayout() {
+        self.addSubviews(lookPagingTabBarView, lineView, lookPagingView)
+        
+        lookPagingTabBarView.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            $0.height.equalTo(44)
+        }
+        
+        lineView.snp.makeConstraints {
+            $0.top.equalTo(lookPagingTabBarView.snp.bottom)
+            $0.height.equalTo(1)
+            $0.leading.trailing.equalToSuperview()
+        }
+        
+        lookPagingView.snp.makeConstraints {
+            $0.top.equalTo(lineView.snp.bottom).offset(5)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+    }
+}
+
+private extension LookView {
+    func setDelegate() {
+        lookPagingTabBarView.delegate = self
+        lookPagingView.pagingTabBar.delegate = self
+        lookPagingView.pagingTabBar.tabBarcollectionView = lookPagingTabBarView.tabBarcollectionView
+    }
+}
+
+extension LookView: PagingDelegate {
+    func didTapPagingTabBarCell(scrollTo indexPath: IndexPath) {
+        lookPagingView.didTapPagingTabBarCell(scrollTo: indexPath)
+    }
+}

--- a/Myhouse/Presentation/LookScene/LookView/View/LookingPagingView.swift
+++ b/Myhouse/Presentation/LookScene/LookView/View/LookingPagingView.swift
@@ -1,0 +1,101 @@
+//
+//  LookingPagingView.swift
+//  Myhouse
+//
+//  Created by 최영린 on 2023/05/22.
+//
+
+import UIKit
+
+import SnapKit
+
+final class LookingPagingView: BaseView {
+    
+   // MARK: - UI Components
+    
+    lazy var pagingTabBar = LookPagingTabBarView()
+    
+    private lazy var contentCollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.showsHorizontalScrollIndicator = false
+        collectionView.isPagingEnabled = true
+        return collectionView
+    }()
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        registerCell()
+        setDelegate()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func setLayout() {
+        self.addSubviews(contentCollectionView)
+        
+        contentCollectionView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}
+
+// MARK: - Extensions
+
+extension LookingPagingView {
+    func registerCell() {
+        LookPagingCollectionViewCell.register(target: contentCollectionView)
+    }
+    
+    func setDelegate() {
+        contentCollectionView.delegate = self
+        contentCollectionView.dataSource = self
+        pagingTabBar.delegate = self
+    }
+}
+
+extension LookingPagingView: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let collectionViewFrame = collectionView.frame
+        return CGSize(width: collectionViewFrame.width, height: collectionViewFrame.height)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        return UIEdgeInsets(top: 0.0, left: 0.0, bottom: 0.0, right: 0.0)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 0.0
+    }
+    
+    func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        let indexPath = IndexPath(row: Int(targetContentOffset.pointee.x / UIScreen.main.bounds.width), section: 0)
+        pagingTabBar.tabBarcollectionView.selectItem(at: indexPath, animated: true, scrollPosition: .centeredHorizontally)
+    }
+}
+
+extension LookingPagingView: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 5
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = LookPagingCollectionViewCell.dequeueReusableCell(collectionView: collectionView, indexPath: indexPath)
+        cell.contentView.addSubview(cell.lookCollectionView)
+        return cell
+    }
+}
+
+extension LookingPagingView: PagingDelegate {
+    func didTapPagingTabBarCell(scrollTo indexPath: IndexPath) {
+        self.contentCollectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
+    }
+}

--- a/Myhouse/Presentation/LookScene/LookView/ViewController/LookViewController.swift
+++ b/Myhouse/Presentation/LookScene/LookView/ViewController/LookViewController.swift
@@ -9,11 +9,9 @@ import UIKit
 
 final class LookViewController: BaseViewController {
     
-    var scrapButtonTapped: (() -> Void)?
-
     // MARK: - UI Components
     
-    private let lookView = LookCollectionView()
+    private let lookView = LookView()
     
     // MARK: - Life Cycles
     
@@ -25,7 +23,6 @@ final class LookViewController: BaseViewController {
         super.viewDidLoad()
         
         setNavigationUI()
-        scrapTapped()
     }
 }
 
@@ -56,11 +53,5 @@ extension LookViewController {
     @objc func scrapNaviItemTapped() {
         let scrapViewController = ScarpViewController()
         self.navigationController?.pushViewController(scrapViewController, animated: false)
-    }
-    
-    func scrapTapped() {
-        lookView.scrapButtonTapped = {
-            self.scrapButtonTapped?()
-        }
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#28

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- SncakBar로 스크랩북으로 이동 시 NavigationBar 안보이는 이슈 해결했습니다 !
- 둘러보기뷰 Paging 구현으로 UI 작업은 완료했습니다. 서버 붙이고 시간 남으면 실제 오늘의 집처럼 Scroll에 따른 Navigation Hidden 처리도 구현해볼게요 .. 
- 각 Tab안의 내용은 사진탭의 CollectionView로 통일 시켜두었습니다 !!

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 기존 ScrapButton 처리를 Delegate로 처리했었는데 뷰 Depth가 깊어지면서 NotificationCenter 로 변경했습니다! ScrapButton 과 TabBarController 확인해주세요!!
- ScrapButton 작업은 완료되었으니 ScrapButton은 UIComponent로 빼둔 ScrapButton으로 사용해주세요 !!
` lazy var scrapButton = ScrapButton()`  이렇게만 가져다 쓰면 됩니다 !!

##  ⁇ 질문
- 첫번째 Tab이 기본적으로 선택되도록 하려고 다음과 같은 코드를 작성하였는데 더 좋은 방법 있으면 공유 부탁드립니다 !! 제발요
```swift
func registerCell() {
        LookPagingTabBarCollectionViewCell.register(target: tabBarcollectionView)
        DispatchQueue.main.async {
            let indexPath = IndexPath(item: 0, section: 0)
            self.tabBarcollectionView.selectItem(at: indexPath, animated: false, scrollPosition: .centeredHorizontally)
        }
    }
```

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/SOPT-32ND-APP2-Myhouse/Myhouse_iOS/assets/75068759/2702bce1-3ab9-46dc-b9d8-51e323a6c765" width ="250">|


## 📟 관련 이슈
- Resolved: #28 
