### PR TITLE
[Feat] #46 - 둘러보기 상세보기 화면 연결

### DIFF
--- a/Myhouse/Network/DataModel/Scrap/AllScrapResponseModel.swift
+++ b/Myhouse/Network/DataModel/Scrap/AllScrapResponseModel.swift
@@ -31,7 +31,7 @@ struct ScrapFolder: Codable {
 // MARK: - Scrap
 struct Scrap: Codable {
     let scrapID: Int
-    let imageURL: String
+    let imageURL: String?
 
     enum CodingKeys: String, CodingKey {
         case scrapID = "scrap_id"

--- a/Myhouse/Presentation/Common/Scrap/FolderTableViewCell.swift
+++ b/Myhouse/Presentation/Common/Scrap/FolderTableViewCell.swift
@@ -64,7 +64,7 @@ extension FolderTableViewCell {
     }
     
     func configureCell(_ scrapData: ScrapFolder) {
-        folderImageView.kf.setImage(with: URL(string: scrapData.scraps[0].imageURL))
+        folderImageView.kf.setImage(with: URL(string: scrapData.scraps[0].imageURL ?? ""))
         folderTitleLabel.text = scrapData.folderTitle
     }
 }

--- a/Myhouse/Presentation/Common/TabBarViewController.swift
+++ b/Myhouse/Presentation/Common/TabBarViewController.swift
@@ -137,13 +137,13 @@ extension TabBarController: ScrapPopUpDelegate {
     func scrapBookButtonTapped() {
         let scrapViewController = ScarpViewController()
         self.navigationController?.isNavigationBarHidden = false
-        self.navigationController?.pushViewController(scrapViewController, animated: false)
+        self.navigationController?.pushViewController(scrapViewController, animated: true)
     }
     
     func folderButtonTapped() {
         let folderViewController = FolderBottomSheetViewController()
         folderViewController.modalTransitionStyle = .coverVertical
         folderViewController.modalPresentationStyle = .overFullScreen
-        self.present(folderViewController, animated: false)
+        self.present(folderViewController, animated: true)
     }
 }

--- a/Myhouse/Presentation/LookScene/DetailView/ViewController/DetailViewController.swift
+++ b/Myhouse/Presentation/LookScene/DetailView/ViewController/DetailViewController.swift
@@ -14,6 +14,7 @@ final class DetailViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setDelegate()
+        setNavigationUI()
     }
     
     override func setLayout() {
@@ -65,5 +66,18 @@ extension DetailViewController: UITableViewDelegate {
         } else {
             return 0
         }
+    }
+    
+    func setNavigationUI() {
+        navigationItem.leftBarButtonItem = UIBarButtonItem(image: ImageLiterals.Common.btn_back, style: .plain, target: self, action: #selector(backButtonTapped))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(image: ImageLiterals.Common.btn_more, style: .plain, target: self, action: #selector(moreButtonTapped))
+    }
+
+    @objc func backButtonTapped() {
+        self.navigationController?.popViewController(animated: false)
+    }
+
+    @objc func moreButtonTapped() {
+        print("More Button Tapped")
     }
 }

--- a/Myhouse/Presentation/LookScene/LookView/View/LookCollectionView.swift
+++ b/Myhouse/Presentation/LookScene/LookView/View/LookCollectionView.swift
@@ -35,6 +35,7 @@ final class LookCollectionView: BaseView {
         let layout = self.getLayout()
         
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.delegate = self
         collectionView.dataSource = self
         return collectionView
     }()
@@ -134,6 +135,15 @@ extension LookCollectionView {
         let section = NSCollectionLayoutSection(group: group)
         
         return section
+    }
+}
+
+extension LookCollectionView: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let userInfo = ["indexPath": indexPath]
+        NotificationCenter.default.post(name: NSNotification.Name("CellTappedNotification"),
+                                        object: nil,
+                                        userInfo: userInfo)
     }
 }
 

--- a/Myhouse/Presentation/LookScene/LookView/ViewController/LookViewController.swift
+++ b/Myhouse/Presentation/LookScene/LookView/ViewController/LookViewController.swift
@@ -23,12 +23,21 @@ final class LookViewController: BaseViewController {
         super.viewDidLoad()
         
         setNavigationUI()
+        setNotificationCenter()
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 }
 
 // MARK: - Extensions
 
 extension LookViewController {
+    
+    func setNotificationCenter() {
+        NotificationCenter.default.addObserver(self, selector: #selector(CellTapped(_:)), name: Notification.Name("CellTappedNotification"), object: nil)
+    }
     
     func setNavigationUI() {
         let scrapButton = UIButton()
@@ -52,6 +61,10 @@ extension LookViewController {
 
     @objc func scrapNaviItemTapped() {
         let scrapViewController = ScarpViewController()
-        self.navigationController?.pushViewController(scrapViewController, animated: false)
+        self.navigationController?.pushViewController(scrapViewController, animated: true)
+    }
+    
+    @objc func CellTapped(_ notification: Notification) {
+        self.navigationController?.pushViewController(DetailViewController(), animated: true)
     }
 }

--- a/Myhouse/Presentation/LookScene/ScarpView/Cell/ScrapCollectionViewCell.swift
+++ b/Myhouse/Presentation/LookScene/ScarpView/Cell/ScrapCollectionViewCell.swift
@@ -160,16 +160,16 @@ extension ScrapCollectionViewCell {
     
     func configureCell(_ scrapData: ScrapFolder) {
         if scrapData.scraps.count >= 1 {
-            imageView1.kf.setImage(with: URL(string: scrapData.scraps[0].imageURL))
+            imageView1.kf.setImage(with: URL(string: scrapData.scraps[scrapData.scraps.count - 1].imageURL ?? ""))
         }
         if scrapData.scraps.count >= 2 {
-            imageView2.kf.setImage(with: URL(string: scrapData.scraps[1].imageURL))
+            imageView2.kf.setImage(with: URL(string: scrapData.scraps[scrapData.scraps.count - 2].imageURL ?? ""))
         }
         if scrapData.scraps.count >= 3 {
-            imageView3.kf.setImage(with: URL(string: scrapData.scraps[2].imageURL))
+            imageView3.kf.setImage(with: URL(string: scrapData.scraps[scrapData.scraps.count - 3].imageURL ?? ""))
         }
         if scrapData.scraps.count >= 4 {
-            imageView4.kf.setImage(with: URL(string: scrapData.scraps[3].imageURL))
+            imageView4.kf.setImage(with: URL(string: scrapData.scraps[scrapData.scraps.count - 4].imageURL ?? ""))
         }
         folderNameLabel.text = scrapData.folderTitle
     }

--- a/Myhouse/Presentation/LookScene/ScarpView/ViewController/ScarpViewController.swift
+++ b/Myhouse/Presentation/LookScene/ScarpView/ViewController/ScarpViewController.swift
@@ -27,7 +27,7 @@ final class ScarpViewController: BaseViewController {
     }
 
     @objc func backButtonTapped() {
-        self.navigationController?.popViewController(animated: false)
+        self.navigationController?.popViewController(animated: true)
     }
 
     @objc func shareButtonTapped() {


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#46

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 둘러보기 상세보기 화면 연결 
- 스크랩모델 변경에 따른 수정
- 상세보기뷰 네비게이션 추가

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 둘러보기 CollectionView의 depth가 너무 깊어서 편하게,, 하기 위해 NotificationCenter로 했습니다 ㅎㅎ

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/SOPT-32ND-APP2-Myhouse/Myhouse_iOS/assets/75068759/849fe0df-73c2-41b2-8c7e-01105eab263e" width ="250">| 

## 📟 관련 이슈
- Resolved: #46 
