### PR TITLE
[Refactor] #60 - 둘러보기 및 폴더 선택 뷰 리팩토링

### DIFF
--- a/Myhouse/Myhouse.xcodeproj/project.pbxproj
+++ b/Myhouse/Myhouse.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		09B7D3A62A12227E00B4B485 /* RecommendDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B7D3A52A12227E00B4B485 /* RecommendDataModel.swift */; };
 		09DF36A12A121D1900C8BDA9 /* RecommendCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DF36A02A121D1900C8BDA9 /* RecommendCollectionViewCell.swift */; };
 		09FD5D412A11676000976C02 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FD5D402A11676000976C02 /* HomeView.swift */; };
+		694B80312A332DF100F74D45 /* ScrapResonseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694B80302A332DF100F74D45 /* ScrapResonseModel.swift */; };
 		694D2FFA2A101A8200D84149 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694D2FF92A101A8200D84149 /* UIImage+.swift */; };
 		694D2FFC2A10B81B00D84149 /* UIVIew+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694D2FFB2A10B81B00D84149 /* UIVIew+.swift */; };
 		694D2FFE2A10B85700D84149 /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694D2FFD2A10B85700D84149 /* UITextField+.swift */; };
@@ -144,6 +145,7 @@
 		09B7D3A52A12227E00B4B485 /* RecommendDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendDataModel.swift; sourceTree = "<group>"; };
 		09DF36A02A121D1900C8BDA9 /* RecommendCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendCollectionViewCell.swift; sourceTree = "<group>"; };
 		09FD5D402A11676000976C02 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		694B80302A332DF100F74D45 /* ScrapResonseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapResonseModel.swift; sourceTree = "<group>"; };
 		694D2FF92A101A8200D84149 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		694D2FFB2A10B81B00D84149 /* UIVIew+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIVIew+.swift"; sourceTree = "<group>"; };
 		694D2FFD2A10B85700D84149 /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
@@ -598,6 +600,7 @@
 			isa = PBXGroup;
 			children = (
 				6975E83A2A1D02D600410B24 /* AllScrapResponseModel.swift */,
+				694B80302A332DF100F74D45 /* ScrapResonseModel.swift */,
 			);
 			path = Scrap;
 			sourceTree = "<group>";
@@ -935,6 +938,7 @@
 				694D30022A10B8C300D84149 /* UIViewController+.swift in Sources */,
 				694D30102A10BCCB00D84149 /* UITableView+.swift in Sources */,
 				694D30182A113A1B00D84149 /* HomeViewController.swift in Sources */,
+				694B80312A332DF100F74D45 /* ScrapResonseModel.swift in Sources */,
 				094373FA2A14A9F7003C8AFD /* ReviewCollectionViewCell.swift in Sources */,
 				9BF93D822A12A8B900FE3B5B /* ModernCollectionViewCell.swift in Sources */,
 				91D0493C2A1BA35C00ADC02F /* DetailTableViewCell.swift in Sources */,

--- a/Myhouse/Network/Base/Config.swift
+++ b/Myhouse/Network/Base/Config.swift
@@ -56,4 +56,6 @@ extension Config {
     
     static let getAllScrapURL = baseURL + "/scrap/all"
     
+    static let postFolderScrapURL = baseURL + "/scrap/"
+    
 }

--- a/Myhouse/Network/DataModel/Scrap/ScrapResonseModel.swift
+++ b/Myhouse/Network/DataModel/Scrap/ScrapResonseModel.swift
@@ -1,0 +1,19 @@
+//
+//  ScrapResonseModel.swift
+//  Myhouse
+//
+//  Created by 최영린 on 2023/06/09.
+//
+
+import Foundation
+
+struct ScrapResponseModel: Codable {
+    let folderID, scrapID: Int
+    let imageURL: String
+
+    enum CodingKeys: String, CodingKey {
+        case folderID = "folder_id"
+        case scrapID = "scrap_id"
+        case imageURL = "image_url"
+    }
+}

--- a/Myhouse/Network/Service/ScrapService.swift
+++ b/Myhouse/Network/Service/ScrapService.swift
@@ -100,10 +100,10 @@ extension ScrapService {
     
     func postScrapFolderAPI(
         imageUrl: String,
-        folderId: String,
+        folderId: Int,
         completion: @escaping (NetworkResult<Any>) -> Void
     ) {
-        let url = "/scrap/\(folderId)"
+        let url = Config.postFolderScrapURL + "\(folderId)"
         let header: HTTPHeaders = NetworkConstant.noTokenHeader
         let body: Parameters = [
             "image_url": imageUrl
@@ -121,7 +121,7 @@ extension ScrapService {
                 guard let data = response.data else { return }
                 let networkResult = self.judgeStatus(by: statusCode,
                                                      data,
-                                                     ScrapFolder.self)
+                                                     ScrapResponseModel.self)
                 completion(networkResult)
             case .failure:
                 completion(.networkFail)

--- a/Myhouse/Presentation/Common/Scrap/FolderBottomSheetView.swift
+++ b/Myhouse/Presentation/Common/Scrap/FolderBottomSheetView.swift
@@ -11,6 +11,7 @@ import SnapKit
 
 protocol FolderDelegate: AnyObject {
     func cancelTapped()
+    func folderTapped()
 }
 
 final class FolderBottomSheetView: BaseView {
@@ -132,10 +133,8 @@ private extension FolderBottomSheetView {
 extension FolderBottomSheetView: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let cell = FolderTableViewCell.dequeueReusableCell(tableView: tableView, indexPath: indexPath)
-        if indexPath.row != 0 {
-            self.postScrapFolder(imagUrl: "", folderId: "1")
-        }
+        self.postScrapFolder(imagUrl: "https://github.com/SOPT-32ND-APP2-Myhouse/Myhouse_Server/assets/77230391/48d9a287-e9de-4943-8a3f-028c5fa193ae", folderId: allFolderData.scrapFolders[indexPath.row + 1].folderID)
+        delegate?.folderTapped()
         print("'\(allFolderData.scrapFolders[indexPath.row + 1].folderTitle)' 폴더로 이동했습니다")
     }
     
@@ -179,18 +178,18 @@ extension FolderBottomSheetView {
         }
     }
     
-    func postScrapFolder(imagUrl: String, folderId: String) {
+    func postScrapFolder(imagUrl: String, folderId: Int) {
         ScrapService.shared.postScrapFolderAPI(
             imageUrl: imagUrl,
             folderId: folderId
         ) { networkResult in
-                switch networkResult {
-                case .success(_):
-                    print("success")
-                default:
-                    break
-                }
-                
+            switch networkResult {
+            case .success:
+                print("success")
+            default:
+                break
             }
+            
+        }
     }
 }

--- a/Myhouse/Presentation/Common/Scrap/FolderBottomSheetViewController.swift
+++ b/Myhouse/Presentation/Common/Scrap/FolderBottomSheetViewController.swift
@@ -79,4 +79,8 @@ extension FolderBottomSheetViewController: FolderDelegate {
     func cancelTapped() {
         hideBottomSheetWithAnimation()
     }
+    
+    func folderTapped() {
+        self.dismiss(animated: false)
+    }
 }

--- a/Myhouse/Presentation/Common/Scrap/FolderTableViewCell.swift
+++ b/Myhouse/Presentation/Common/Scrap/FolderTableViewCell.swift
@@ -64,7 +64,7 @@ extension FolderTableViewCell {
     }
     
     func configureCell(_ scrapData: ScrapFolder) {
-        folderImageView.kf.setImage(with: URL(string: scrapData.scraps[0].imageURL ?? ""))
+        folderImageView.kf.setImage(with: URL(string: scrapData.scraps[scrapData.scraps.count - 1].imageURL ?? ""))
         folderTitleLabel.text = scrapData.folderTitle
     }
 }

--- a/Myhouse/Presentation/LookScene/LookView/View/LookCollectionView.swift
+++ b/Myhouse/Presentation/LookScene/LookView/View/LookCollectionView.swift
@@ -140,10 +140,16 @@ extension LookCollectionView {
 
 extension LookCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let userInfo = ["indexPath": indexPath]
-        NotificationCenter.default.post(name: NSNotification.Name("CellTappedNotification"),
-                                        object: nil,
-                                        userInfo: userInfo)
+        let sectionType = SectionType.allCases[indexPath.section]
+        switch sectionType {
+        case .tag:
+            break
+        case .feed:
+            let userInfo = ["indexPath": indexPath]
+            NotificationCenter.default.post(name: NSNotification.Name("CellTappedNotification"),
+                                            object: nil,
+                                            userInfo: userInfo)
+        }
     }
 }
 


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#60

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 둘러보기 뷰에서 셀 클릭 분기처리를 해주지 않아서 태그만 눌러도 Detail로 이동하던 이슈 해결
- 폴더 선택 시 폴더 이미지 최근 이미지로 변경
- 폴더 선택 API 수정
- 폴더 선택하면 바텀시트 숨기기

## 💌 T0. 팀원들
<!-- 참고할 사항이 있다면 적어주세요. -->
- 시험이슈로 많이 못고쳤습니다 ,,, 미안합니다 다들 화이팅 !

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/SOPT-32ND-APP2-Myhouse/Myhouse_iOS/assets/75068759/b73a46c0-0498-470a-bd97-3fa78f56a048" width ="250">|

## 📟 관련 이슈
- Resolved: #60 
